### PR TITLE
feat: add Cluedo tile classes: AbstractCluedoTile, CorridorTile, and RoomTile

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/AbstractCluedoTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/AbstractCluedoTile.java
@@ -1,0 +1,65 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.board;
+
+import edu.ntnu.idi.idatt.boardgame.core.domain.board.Tile;
+import edu.ntnu.idi.idatt.boardgame.core.domain.player.Player;
+import edu.ntnu.idi.idatt.boardgame.core.engine.event.TileObserver;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Grid-based tile with (row,col) coordinates and default observer support. */
+public abstract class AbstractCluedoTile implements Tile {
+
+  protected final int row; // 0-based board coordinates
+  protected final int col;
+  protected final List<Player> players = new ArrayList<>();
+
+  private final List<TileObserver> observers = new ArrayList<>();
+
+  protected AbstractCluedoTile(int row, int col) {
+    this.row = row;
+    this.col = col;
+  }
+
+  @Override
+  public void addPlayer(Player player) {
+    players.add(player);
+    notifyChange();
+  }
+
+  @Override
+  public void removePlayer(Player player) {
+    players.remove(player);
+    notifyChange();
+  }
+
+  @Override
+  public String getIdentifier() {
+    return "%s(%d,%d)".formatted(getClass().getSimpleName(), row, col);
+  }
+
+  @Override
+  public void addObserver(TileObserver obs) {
+    observers.add(obs);
+  }
+
+  @Override
+  public void removeObserver(TileObserver obs) {
+    observers.remove(obs);
+  }
+
+  protected void notifyChange() {
+    observers.forEach(o -> o.onTileChanged(this));
+  }
+
+  public int row() {
+    return row;
+  }
+
+  public int col() {
+    return col;
+  }
+
+  public List<Player> getPlayers() {
+    return List.copyOf(players);
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CorridorTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CorridorTile.java
@@ -1,0 +1,14 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.board;
+
+/** A single walkable square on the Cluedo board. */
+public final class CorridorTile extends AbstractCluedoTile {
+
+  public CorridorTile(int row, int col) {
+    super(row, col);
+  }
+
+  /** Corridor squares are always enterable. */
+  public boolean isWalkable() {
+    return true;
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/RoomTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/RoomTile.java
@@ -1,0 +1,100 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.board;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * A room described by an ordered list of corner points that form the perimeter.
+ *
+ * <p>Edges (p[i] → p[i+1]) are walls except those registered via {@link #addDoor}. Coordinates are
+ * board squares (row, col), 0-based.
+ */
+public final class RoomTile extends AbstractCluedoTile {
+
+  /** Name shown on cards / UI */
+  private final String roomName;
+
+  /** Ordered perimeter; first == last. */
+  private final List<Point> outline;
+
+  /** Set of edges that are open doorways. */
+  private final Set<Edge> doorEdges = new HashSet<>();
+
+  /**
+   * @param roomName logical name (“Kitchen”)
+   * @param outlinePerimeter ordered points, first = last (minimum 4)
+   */
+  public RoomTile(String roomName, List<Point> outlinePerimeter) {
+    // we store row/col of an arbitrary interior square
+    super(outlinePerimeter.get(0).row(), outlinePerimeter.get(0).col());
+    if (outlinePerimeter.size() < 4)
+      throw new IllegalArgumentException("Outline requires ≥ 4 points");
+    if (!outlinePerimeter.get(0).equals(outlinePerimeter.get(outlinePerimeter.size() - 1)))
+      throw new IllegalArgumentException("First and last outline point must match");
+    this.roomName = Objects.requireNonNull(roomName);
+    this.outline = List.copyOf(outlinePerimeter);
+  }
+
+  /** Marks the edge (p1 → p2) as a doorway. Call after construction. */
+  public void addDoor(Point p1, Point p2) {
+    Edge e = new Edge(p1, p2);
+    if (!isPerimeterEdge(e))
+      throw new IllegalArgumentException("Edge " + e + " not on room perimeter");
+    doorEdges.add(e);
+  }
+
+  /** Corridor square (r,c) may enter if its edge to this room is a door. */
+  public boolean canEnterFrom(int r, int c) {
+    Point corridor = new Point(r, c);
+    // look for a perimeter edge adjoining the corridor square
+    return perimeterEdges().stream().anyMatch(e -> doorEdges.contains(e) && e.adjacentTo(corridor));
+  }
+
+  private List<Edge> perimeterEdges() {
+	  return IntStream.range(0, outline.size() - 1)
+	      .mapToObj(i -> new Edge(outline.get(i), outline.get(i + 1)))
+	      .collect(Collectors.toList());
+  }
+
+  private boolean isPerimeterEdge(Edge e) {
+    return perimeterEdges().contains(e);
+  }
+
+  public String getRoomName() {
+    return roomName;
+  }
+
+  public List<Point> getOutline() {
+    return outline;
+  }
+
+  public Set<Edge> getDoors() {
+    return Set.copyOf(doorEdges);
+  }
+
+  public record Point(int row, int col) {}
+
+  /** Undirected edge between two adjacent squares. */
+  public record Edge(Point a, Point b) {
+    public Edge {
+      if (Math.abs(a.row() - b.row()) + Math.abs(a.col() - b.col()) != 1)
+        throw new IllegalArgumentException("Edge must connect adjacent squares");
+    }
+
+    boolean adjacentTo(Point p) {
+      return p.equals(a) || p.equals(b);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof Edge e
+          && (e.a.equals(a) && e.b.equals(b) || e.a.equals(b) && e.b.equals(a));
+    }
+
+    @Override
+    public int hashCode() {
+      return a.hashCode() + b.hashCode();
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new tile system for the Cluedo board game, including an abstract base class for tiles and two concrete implementations: `CorridorTile` and `RoomTile`. These changes establish a foundation for representing and interacting with different types of tiles on the game board.

### New tile system:

* **Abstract base class for tiles:**
  - Added `AbstractCluedoTile` as a base class for all Cluedo tiles. It includes common functionality such as managing players on a tile, notifying observers of changes, and providing tile coordinates. (`src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/AbstractCluedoTile.java`)

* **Corridor tiles:**
  - Introduced `CorridorTile`, a concrete subclass of `AbstractCluedoTile`, representing walkable squares on the board. It is always walkable. (`src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CorridorTile.java`)

* **Room tiles:**
  - Added `RoomTile`, a concrete subclass of `AbstractCluedoTile`, representing rooms with defined perimeters and doorways. It includes functionality to check if a corridor square can enter the room via a door. (`src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/RoomTile.java`)