### PR TITLE
refactor: move color mapping to util from domain

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/core/domain/player/PlayerColor.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/core/domain/player/PlayerColor.java
@@ -1,24 +1,10 @@
 package edu.ntnu.idi.idatt.boardgame.core.domain.player;
 
-import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
-
 public enum PlayerColor {
   RED,
   BLUE,
   GREEN,
   YELLOW,
   ORANGE,
-  PURPLE;
-
-  public static Paint mapToJavaFXColor(PlayerColor color) {
-    return switch (color) {
-      case RED -> Color.RED;
-      case BLUE -> Color.BLUE;
-      case GREEN -> Color.GREEN;
-      case YELLOW -> Color.YELLOW;
-      case ORANGE -> Color.ORANGE;
-      case PURPLE -> Color.PURPLE;
-    };
-  }
+  PURPLE,
 }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/view/SnLTileView.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/view/SnLTileView.java
@@ -4,6 +4,7 @@ import edu.ntnu.idi.idatt.boardgame.core.domain.board.Tile;
 import edu.ntnu.idi.idatt.boardgame.core.engine.event.TileObserver;
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.PlayerColor;
 import edu.ntnu.idi.idatt.boardgame.games.snakesandladders.domain.board.SnLTile;
+import edu.ntnu.idi.idatt.boardgame.ui.util.PlayerColorMapper;
 import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -74,7 +75,7 @@ public class SnLTileView implements TileObserver {
         .forEach(
             player -> {
               Circle circle = new Circle(7);
-              circle.setFill(PlayerColor.mapToJavaFXColor(player.getColor()));
+              circle.setFill(PlayerColorMapper.toPaint(player.getColor()));
               playerBox.getChildren().add(circle);
             });
     tileContainer.getChildren().add(playerBox);

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/MainView.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/MainView.java
@@ -142,7 +142,6 @@ public class MainView {
             return;
           }
           currentController.loadGameState(file.getPath());
-          System.out.println("Game state loaded. View refresh might be needed.");
           saveGameButton.setDisable(false);
           loadGameButton.setDisable(false);
         });

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/util/PlayerColorMapper.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/util/PlayerColorMapper.java
@@ -1,0 +1,19 @@
+
+package edu.ntnu.idi.idatt.boardgame.ui.util;
+
+import edu.ntnu.idi.idatt.boardgame.core.domain.player.PlayerColor;
+import javafx.scene.paint.Paint;
+import javafx.scene.paint.Color;
+
+public final class PlayerColorMapper {
+	public static Paint toPaint(PlayerColor c) {
+		return switch(c) {
+			case RED    -> Color.RED;
+			case BLUE   -> Color.BLUE;
+			case GREEN  -> Color.GREEN;
+			case YELLOW -> Color.YELLOW;
+			case ORANGE -> Color.ORANGE;
+			case PURPLE -> Color.PURPLE;
+		};
+	}
+}


### PR DESCRIPTION
This pull request refactors the handling of player colors in the codebase by introducing a new utility class, `PlayerColorMapper`, and removes the color mapping logic from the `PlayerColor` enum. Additionally, it includes minor cleanup in the `MainView` class. Below are the most important changes grouped by theme:

### Refactoring player color mapping:

* Removed the `mapToJavaFXColor` method from the `PlayerColor` enum and its associated imports, simplifying the enum to only define color constants. (`src/main/java/edu/ntnu/idi/idatt/boardgame/core/domain/player/PlayerColor.java`)
* Created a new utility class `PlayerColorMapper` in the `ui.util` package to handle the mapping of `PlayerColor` to JavaFX `Paint` objects. This centralizes the color mapping logic. (`src/main/java/edu/ntnu/idi/idatt/boardgame/ui/util/PlayerColorMapper.java`)
* Updated the `SnLTileView` class to use `PlayerColorMapper.toPaint` instead of the removed `PlayerColor.mapToJavaFXColor` method for setting player colors. (`src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/view/SnLTileView.java`)

### Code cleanup:

* Removed a debug `System.out.println` statement from the `buildLoadButton` method in the `MainView` class, improving code cleanliness. (`src/main/java/edu/ntnu/idi/idatt/boardgame/ui/MainView.java`)