### PR TITLE
fix: use return value of dir.mkdirs() and add error handling to it

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/MainView.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/MainView.java
@@ -85,7 +85,12 @@ public class MainView {
           chooser.setTitle("Save Game State");
           File dir = new File("saves");
           if (!dir.exists()) {
-            dir.mkdirs();
+            boolean success = dir.mkdirs();
+
+            if (!success) {
+              System.out.println("Failed to create saves directory.");
+              return;
+            }
           }
           chooser.setInitialDirectory(dir);
           chooser.setInitialFileName("game_state.json");


### PR DESCRIPTION
This pull request includes a small but important change to improve error handling when creating the "saves" directory in the `buildSaveButton` method. If directory creation fails, the code now logs an error message and exits the method to prevent further issues. 

* [`src/main/java/edu/ntnu/idi/idatt/boardgame/ui/MainView.java`](diffhunk://#diff-ed0afb156a98a256307cd2009b4714e9731dce82d7540ec3ed72763001ba2d2bL88-R93): Added a check for the success of `mkdirs()` and an error message if the "saves" directory cannot be created.