### PR TITLE
fix: make report submodule track its main branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "report"]
 	path = report
 	url = https://github.com/Tmpecho/Mappeoppgave-prog-2-rapport
+	branch = main


### PR DESCRIPTION
This pull request updates the configuration for the `report` submodule. The most important changes include specifying the branch to track and updating the submodule to a new commit.

Submodule configuration updates:

* [`.gitmodules`](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R4): Added the `branch = main` setting to explicitly track the `main` branch for the `report` submodule.

Submodule update:

* [`report`](diffhunk://#diff-845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917L1-R1): Updated the submodule to point to a new commit (`32bf8ce42e91e5c8df02555798b2350ea36e2d1d`) from the previous commit (`ddea948a95419f500c23dd37ecca79cb854bc6f2`).