### PR TITLE
feat(cluedo): refactor suspects

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/Cards.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/Cards.java
@@ -3,10 +3,7 @@ package edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card;
 import java.util.*;
 
 public final class Cards {
-  private static final String[] SUSPECTS = {
-    "Miss Scarlet", "Colonel Mustard", "Mrs. White",
-    "Reverend Green", "Mrs. Peacock", "Professor Plum"
-  };
+  private static final String[] SUSPECTS = Suspect.names();
   private static final String[] WEAPONS = {
     "Candlestick", "Knife", "Lead Pipe",
     "Revolver", "Rope", "Wrench"

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/Suspect.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/Suspect.java
@@ -1,0 +1,47 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card;
+
+import edu.ntnu.idi.idatt.boardgame.core.domain.player.PlayerColor;
+import edu.ntnu.idi.idatt.boardgame.ui.util.LoggingNotification;
+import java.util.Arrays;
+
+public enum Suspect {
+  MISS_SCARLETT(PlayerColor.WHITE, "Miss Scarlett"),
+  COLONEL_MUSTARD(PlayerColor.RED, "Col. Mustard"),
+  MRS_WHITE(PlayerColor.YELLOW, "Mrs. White"),
+  REVEREND_GREEN(PlayerColor.GREEN, "Rev. Green"),
+  MRS_PEACOCK(PlayerColor.BLUE, "Mrs. Peacock"),
+  PROFESSOR_PLUM(PlayerColor.PURPLE, "Prof. Plum");
+
+  private final PlayerColor colour;
+  private final String displayName;
+
+  Suspect(PlayerColor colour, String displayName) {
+    this.colour = colour;
+    this.displayName = displayName;
+  }
+
+  /** Convenience: every suspect’s display name in game-order (needed by {@code Cards}). */
+  public static String[] names() {
+    return Arrays.stream(values()).map(Suspect::displayName).toArray(String[]::new);
+  }
+
+  public static Suspect from(PlayerColor playerColor) {
+    return Arrays.stream(values())
+        .filter(suspect -> suspect.colour == playerColor)
+        .findFirst()
+        .orElseThrow(
+            () -> {
+              LoggingNotification.error(
+                  "No suspect for color", "No suspect found for " + playerColor);
+              return new IllegalArgumentException("No suspect for " + playerColor);
+            });
+  }
+
+  public PlayerColor colour() {
+    return colour;
+  }
+
+  public String displayName() {
+    return displayName;
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/Suspect.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/Suspect.java
@@ -25,14 +25,27 @@ public enum Suspect {
     return Arrays.stream(values()).map(Suspect::displayName).toArray(String[]::new);
   }
 
+  /**
+   * Maps a {@link PlayerColor} to its {@code Suspect}.
+   *
+   * @throws NullPointerException if {@code playerColor} is {@code null}
+   * @throws IllegalArgumentException if the colour is not used by any suspect
+   */
   public static Suspect from(PlayerColor playerColor) {
+    if (playerColor == null) {
+      throw new NullPointerException("playerColor is null");
+    }
+
     return Arrays.stream(values())
-        .filter(suspect -> suspect.colour == playerColor)
+        .filter(s -> s.colour == playerColor)
         .findFirst()
         .orElseThrow(
             () -> {
-              LoggingNotification.error(
-                  "No suspect for color", "No suspect found for " + playerColor);
+              // swallow any JavaFX-initialization problems
+              try {
+                LoggingNotification.error("Unknown colour", "No suspect for " + playerColor);
+              } catch (RuntimeException ignored) {
+              }
               return new IllegalArgumentException("No suspect for " + playerColor);
             });
   }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/controller/CluedoController.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/controller/CluedoController.java
@@ -3,7 +3,6 @@ package edu.ntnu.idi.idatt.boardgame.games.cluedo.engine.controller;
 import edu.ntnu.idi.idatt.boardgame.core.domain.dice.Dice;
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.GridPos;
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.Player;
-import edu.ntnu.idi.idatt.boardgame.core.domain.player.PlayerColor;
 import edu.ntnu.idi.idatt.boardgame.core.engine.controller.GameController;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.board.CluedoBoard;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.board.CorridorTile;
@@ -11,6 +10,7 @@ import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.board.RoomTile;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Card;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.CardType;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Cards;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Suspect;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.player.CluedoPlayer;
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -29,25 +29,7 @@ public final class CluedoController extends GameController<GridPos> {
   private List<Card> deck = new ArrayList<>();
   private final Card[] solution = new Card[3];
   private final Random rng = new SecureRandom();
-
-  private final List<PlayerColor> playerColors =
-      List.of(
-          PlayerColor.WHITE, // Miss Scarlett
-          PlayerColor.RED, // Col. Mustard
-          PlayerColor.BLUE, // Mrs. Peacock
-          PlayerColor.GREEN, // Rev. Green
-          PlayerColor.YELLOW, // Mrs. White
-          PlayerColor.PURPLE // Prof. Plum
-          );
-
-  private final Map<PlayerColor, String> playerNames =
-      Map.of(
-          PlayerColor.WHITE, "Miss Scarlett",
-          PlayerColor.RED, "Col. Mustard",
-          PlayerColor.BLUE, "Mrs. Peacock",
-          PlayerColor.GREEN, "Rev. Green",
-          PlayerColor.YELLOW, "Mrs. White",
-          PlayerColor.PURPLE, "Prof. Plum");
+  private final List<Suspect> suspects = List.of(Suspect.values());
 
   public CluedoController(int numberOfPlayers) {
     super(new CluedoBoard(), new Dice(2));
@@ -74,9 +56,9 @@ public final class CluedoController extends GameController<GridPos> {
     IntStream.rangeClosed(1, n)
         .forEach(
             i -> {
-              PlayerColor colour = playerColors.get(i - 1);
-              String name = playerNames.get(colour);
-              CluedoPlayer player = new CluedoPlayer(i, name, colour, new GridPos(0, 0));
+              Suspect suspect = suspects.get(i - 1);
+              CluedoPlayer player =
+                  new CluedoPlayer(i, suspect.displayName(), suspect.colour(), new GridPos(0, 0));
               map.put(i, player);
             });
     return map;

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/SuspectTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/SuspectTest.java
@@ -1,0 +1,73 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import edu.ntnu.idi.idatt.boardgame.core.domain.player.PlayerColor;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link Suspect}. */
+class SuspectTest {
+
+  @Nested
+  @DisplayName("names()")
+  class Names {
+
+    @Test
+    @DisplayName("returns every display name in enum-declaration order")
+    void returnsNamesInOrder() {
+      String[] names = Suspect.names();
+      Suspect[] values = Suspect.values();
+
+      assertEquals(values.length, names.length, "Array size should match enum size");
+
+      IntStream.range(0, values.length)
+          .forEach(
+              i ->
+                  assertEquals(
+                      values[i].displayName(),
+                      names[i],
+                      "names()["
+                          + i
+                          + "] should equal displayName() of the "
+                          + i
+                          + "-th enum constant"));
+    }
+  }
+
+  @Nested
+  @DisplayName("from(PlayerColor)")
+  class From {
+
+    @Test
+    @DisplayName("maps every colour used in the enum")
+    void mapsEveryDefinedColour() {
+      for (Suspect s : Suspect.values()) {
+        assertEquals(
+            s,
+            Suspect.from(s.colour()),
+            "Suspect.from(colour) should return the enum constant with that colour");
+      }
+    }
+
+    @Test
+    @DisplayName("throws when colour is not mapped")
+    void throwsForUnknownColour() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> Suspect.from(PlayerColor.ORANGE),
+          "ORANGE is not mapped to a Suspect and should cause an exception");
+    }
+
+    @Test
+    @DisplayName("throws when colour is null")
+    void throwsForNull() {
+      assertThrows(
+          NullPointerException.class,
+          () -> Suspect.from(null),
+          "Passing null should result in a NullPointerException");
+    }
+  }
+}


### PR DESCRIPTION
This pull request refactors the handling of suspects in the Cluedo game domain by introducing a new `Suspect` enum, replacing hardcoded suspect data with a more structured and extensible approach. It also includes corresponding updates to the `Cards` and `CluedoController` classes and adds unit tests for the `Suspect` enum.

### Refactoring suspect handling:

* **Introduced `Suspect` enum**: Added a new `Suspect` enum to encapsulate suspect-related data, including their `PlayerColor` and display names. This enum provides utility methods such as `names()` for retrieving all display names and `from(PlayerColor)` for mapping a color to a suspect. (`src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/Suspect.java`)

* **Replaced hardcoded suspect data**: Updated the `Cards` class to use `Suspect.names()` instead of a hardcoded array for suspect names. (`src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/Cards.java`)

* **Simplified `CluedoController` suspect management**: Replaced hardcoded lists and maps of `PlayerColor` and suspect names with a single list of `Suspect` enums. Updated the `createPlayers` method to use the `Suspect` enum for creating players. (`src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/controller/CluedoController.java`) [[1]](diffhunk://#diff-f2b9ae79f5eb19902544bd40c428b2580fe388fce2e0ad4c059ee6ba60a26c40L32-R32) [[2]](diffhunk://#diff-f2b9ae79f5eb19902544bd40c428b2580fe388fce2e0ad4c059ee6ba60a26c40L77-R61)

### Testing:

* **Added unit tests for `Suspect`**: Created a new test class `SuspectTest` to verify the functionality of the `Suspect` enum, including tests for `names()` and `from(PlayerColor)`. (`src/test/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/card/SuspectTest.java`)