### PR TITLE
refactor: remove generic `incrementPlayerPosition` method

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/core/domain/board/GameBoard.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/core/domain/board/GameBoard.java
@@ -1,15 +1,12 @@
 package edu.ntnu.idi.idatt.boardgame.core.domain.board;
 
-import java.util.Map;
-
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.Player;
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.Position;
+import java.util.Map;
 
 public interface GameBoard<P extends Position> {
 
   void addPlayersToStart(Map<Integer, Player<P>> players);
-
-  void incrementPlayerPosition(Player<P> player, int increment);
 
   int getBoardSize();
 

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CluedoBoard.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CluedoBoard.java
@@ -361,12 +361,6 @@ public final class CluedoBoard implements GameBoard<GridPos> {
                     });
   }
 
-  @Override
-  public void incrementPlayerPosition(Player<GridPos> player, int increment) {
-    System.out.println(
-            "Warning: incrementPlayerPosition called. This method is not suitable for standard Cluedo movement.");
-  }
-
   public AbstractCluedoTile getTileAtPosition(GridPos pos) {
     if (isValidPosition(pos)) {
       return board[pos.row()][pos.col()];

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/domain/board/SnLBoard.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/domain/board/SnLBoard.java
@@ -54,17 +54,16 @@ public final class SnLBoard implements GameBoard<LinearPos> {
             });
   }
 
-  @Override
   public void incrementPlayerPosition(Player<LinearPos> player, int inc) {
     int from = player.getPosition().index();
     int to = computeDestination(from + inc);
-    move(player, from, to);
+    movePlayer(player, from, to);
     applyConnector(player);
   }
 
   @Override
   public void setPlayerPosition(Player<LinearPos> player, LinearPos pos) {
-    move(player, player.getPosition().index(), pos.index());
+    movePlayer(player, player.getPosition().index(), pos.index());
   }
 
   @Override
@@ -79,7 +78,7 @@ public final class SnLBoard implements GameBoard<LinearPos> {
     return Math.max(raw, 1);
   }
 
-  private void move(Player<LinearPos> p, int from, int to) {
+  private void movePlayer(Player<LinearPos> p, int from, int to) {
     tiles.get(from).removePlayer(p);
     p.setPosition(new LinearPos(to));
     tiles.get(to).addPlayer(p);
@@ -91,7 +90,7 @@ public final class SnLBoard implements GameBoard<LinearPos> {
     if (c == null) {
       return;
     }
-    move(p, pos, computeDestination(c.getEnd()));
+    movePlayer(p, pos, computeDestination(c.getEnd()));
   }
 
   private SnLTile getTileAtPosition(int pos) {

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/engine/action/RollAction.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/engine/action/RollAction.java
@@ -1,17 +1,17 @@
 package edu.ntnu.idi.idatt.boardgame.games.snakesandladders.engine.action;
 
-import edu.ntnu.idi.idatt.boardgame.core.domain.board.GameBoard;
 import edu.ntnu.idi.idatt.boardgame.core.domain.dice.Dice;
+import edu.ntnu.idi.idatt.boardgame.core.domain.player.LinearPos;
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.Player;
-import edu.ntnu.idi.idatt.boardgame.core.domain.player.Position;
 import edu.ntnu.idi.idatt.boardgame.core.engine.action.Action;
+import edu.ntnu.idi.idatt.boardgame.games.snakesandladders.domain.board.SnLBoard;
 
-public final class RollAction<P extends Position> implements Action {
-  private final GameBoard<P> gameBoard;
-  private final Player<P> player;
+public final class RollAction implements Action {
+  private final SnLBoard gameBoard;
+  private final Player<LinearPos> player;
   private final Dice dice;
 
-  public RollAction(GameBoard<P> gameBoard, Player<P> player, Dice dice) {
+  public RollAction(SnLBoard gameBoard, Player<LinearPos> player, Dice dice) {
     this.gameBoard = gameBoard;
     this.player = player;
     this.dice = dice;

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/engine/controller/SnLController.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/engine/controller/SnLController.java
@@ -65,7 +65,7 @@ public final class SnLController extends GameController<LinearPos> {
   }
 
   public void rollDice() {
-    Action roll = new RollAction<>(gameBoard, currentPlayer, dice);
+    Action roll = new RollAction((SnLBoard) gameBoard, currentPlayer, dice);
     roll.execute();
     notifyObservers(currentPlayer.getName() + " is now at tile " + currentPlayer.getPosition());
     if (isGameOver()) {

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CluedoBoardTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CluedoBoardTest.java
@@ -220,16 +220,4 @@ class CluedoBoardTest {
     assertNull(board.getTileAtPosition(new GridPos(25, 5)));
     assertNull(board.getTileAtPosition(new GridPos(5, 25)));
   }
-
-  // TODO: remove incrementplayerposition with test
-  @Test
-  void incrementPlayerPosition_logsWarningAndDoesNotChangePosition() {
-    board.addPlayersToStart(players);
-    GridPos initialPos = missScarlett.getPosition();
-    board.incrementPlayerPosition(missScarlett, 5);
-    assertEquals(
-            initialPos,
-            missScarlett.getPosition(),
-            "incrementPlayerPosition should not change position in Cluedo");
-  }
 }

--- a/src/test/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/domain/board/SnLBoardTest.java
+++ b/src/test/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/domain/board/SnLBoardTest.java
@@ -59,7 +59,7 @@ class SnLBoardTest {
   }
 
   @Test
-  void incrementPlayerPosition_normalMove() {
+  void incrementPlayerPosition_normalMovePlayer() {
     board.addPlayersToStart(playersMap);
     board.incrementPlayerPosition(player1, 5);
     assertEquals(new LinearPos(6), player1.getPosition());


### PR DESCRIPTION
Eliminated `incrementPlayerPosition` from `GameBoard` and irrelevant implementations in Cluedo. Updated Snakes and Ladders to use `movePlayer` for improved clarity and action specificity.