### PR TITLE
feat(cluedo): Add note-taking functionality for Cluedo players

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/player/CluedoPlayer.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/player/CluedoPlayer.java
@@ -8,7 +8,14 @@ import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Room;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Suspect;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Weapon;
 import edu.ntnu.idi.idatt.boardgame.ui.util.LoggingNotification;
-import java.util.*;
+import java.util.HashSet;
+import java.util.EnumMap;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.Map;
+import java.util.List;
+import java.util.Collection;
+import java.util.Random;
 
 public final class CluedoPlayer extends Player<GridPos> {
   private final Set<Suspect> suspectHand = new HashSet<>();

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/player/CluedoPlayer.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/player/CluedoPlayer.java
@@ -8,19 +8,22 @@ import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Room;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Suspect;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Weapon;
 import edu.ntnu.idi.idatt.boardgame.ui.util.LoggingNotification;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
 public final class CluedoPlayer extends Player<GridPos> {
   private final Set<Suspect> suspectHand = new HashSet<>();
   private final Set<Weapon> weaponHand = new HashSet<>();
   private final Set<Room> roomHand = new HashSet<>();
+  private final Map<Suspect, Boolean> suspectNotes = new EnumMap<>(Suspect.class);
+  private final Map<Weapon, Boolean> weaponNotes = new EnumMap<>(Weapon.class);
+  private final Map<Room, Boolean> roomNotes = new EnumMap<>(Room.class);
 
   public CluedoPlayer(int id, String name, PlayerColor color, GridPos startPos) {
     super(id, name, color, startPos);
+
+    Arrays.stream(Suspect.values()).forEach(suspect -> suspectNotes.put(suspect, false));
+    Arrays.stream(Weapon.values()).forEach(weapon -> weaponNotes.put(weapon, false));
+    Arrays.stream(Room.values()).forEach(room -> roomNotes.put(room, false));
   }
 
   public void addCard(Suspect suspect) {
@@ -72,5 +75,29 @@ public final class CluedoPlayer extends Player<GridPos> {
       throw new IllegalArgumentException("No cards to show");
     }
     return matches.get(rng.nextInt(matches.size()));
+  }
+
+  public boolean isSuspectNoted(Suspect s) {
+    return suspectNotes.get(s);
+  }
+
+  public void setSuspectNoted(Suspect s, boolean v) {
+    suspectNotes.put(s, v);
+  }
+
+  public boolean isWeaponNoted(Weapon w) {
+    return weaponNotes.get(w);
+  }
+
+  public void setWeaponNoted(Weapon w, boolean v) {
+    weaponNotes.put(w, v);
+  }
+
+  public boolean isRoomNoted(Room r) {
+    return roomNotes.get(r);
+  }
+
+  public void setRoomNoted(Room r, boolean v) {
+    roomNotes.put(r, v);
   }
 }


### PR DESCRIPTION
Introduced a notes section in the Cluedo UI, allowing players to track suspects, weapons, and rooms using checkboxes. Updated the `CluedoPlayer` class to manage this data with maps and enabled synchronization between the UI and player state. This improves gameplay by providing a structured way to maintain notes.