### PR TITLE
chore: replace system print with loggers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
@@ -47,11 +48,11 @@
       <artifactId>gson</artifactId>
       <version>2.11.0</version>
     </dependency>
-      <dependency>
-          <groupId>org.controlsfx</groupId>
-          <artifactId>controlsfx</artifactId>
-          <version>11.2.1</version>
-      </dependency>
+    <dependency>
+      <groupId>org.controlsfx</groupId>
+      <artifactId>controlsfx</artifactId>
+      <version>11.2.1</version>
+    </dependency>
     <dependency>
       <groupId>org.testfx</groupId>
       <artifactId>testfx-junit5</artifactId>
@@ -63,6 +64,16 @@
       <artifactId>mockito-core</artifactId>
       <version>5.17.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.17</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.5.18</version>
     </dependency>
   </dependencies>
 
@@ -109,17 +120,17 @@
           <version>3.6.1</version>
         </plugin>
         <plugin>
-            <groupId>org.openjfx</groupId>
-            <artifactId>javafx-maven-plugin</artifactId>
-            <version>0.0.8</version>
-            <executions>
-                <execution>
-                    <id>default-cli</id>
-                    <goals>
-                      <goal>run</goal>
-                    </goals>
-                </execution>
-            </executions>
+          <groupId>org.openjfx</groupId>
+          <artifactId>javafx-maven-plugin</artifactId>
+          <version>0.0.8</version>
+          <executions>
+            <execution>
+              <id>default-cli</id>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
           <configuration>
             <mainClass>edu.ntnu.idi.idatt.boardgame.App</mainClass>
           </configuration>

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CluedoBoard.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/CluedoBoard.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Represents the game board for Cluedo. It defines the layout of rooms, corridors, and borders, as
@@ -15,6 +17,7 @@ import java.util.stream.IntStream;
  */
 public final class CluedoBoard implements GameBoard<GridPos> {
 
+  private static final Logger logger = LoggerFactory.getLogger(CluedoBoard.class);
   private static final int BOARD_SIZE = 25;
 
   // Player starting positions
@@ -192,7 +195,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
       for (int c = roomDimensions.left; c <= roomDimensions.right; c++) {
         if (r >= 0 && r < BOARD_SIZE && c >= 0 && c < BOARD_SIZE) {
           if (board[r][c] != null) {
-            System.err.println(
+            logger.warn(
                 "Warning: Overwriting existing tile at ("
                     + r
                     + ", "
@@ -205,7 +208,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
           board[r][c] = room;
           room.setWalkable(false);
         } else {
-          System.err.println(
+          logger.warn(
               "Warning: Attempted to populate room tile outside board bounds at ("
                   + r
                   + ", "
@@ -224,7 +227,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
               || spec.dims.left < 1
               || spec.dims.bottom >= BOARD_SIZE - 1
               || spec.dims.right >= BOARD_SIZE - 1) {
-            System.err.println(
+            logger.error(
                 "CRITICAL Error: Room "
                     + spec.name
                     + " with dimensions "
@@ -240,7 +243,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
             try {
               room.addDoor(doorDef.roomSide(), doorDef.corridorSide());
             } catch (IllegalArgumentException e) {
-              System.err.println(
+              logger.error(
                   "Error adding door for room "
                       + spec.name
                       + " between "
@@ -339,24 +342,24 @@ public final class CluedoBoard implements GameBoard<GridPos> {
   @Override
   public void setPlayerPosition(Player<GridPos> player, GridPos position) {
     if (!isValidPosition(position)) {
-      System.err.println("Error: Attempt to set invalid position " + position);
+      logger.error("Error: Attempt to set invalid position " + position);
       return;
     }
     AbstractCluedoTile targetTile = getTileAtPosition(position);
     if (targetTile
         == null) { // Should not happen if isValidPosition is true and board is fully initialized
-      System.err.println("CRITICAL Error: Target tile is null at valid position " + position);
+      logger.error("CRITICAL Error: Target tile is null at valid position " + position);
       return;
     }
 
     if (targetTile instanceof BorderTile) {
-      System.err.println("Error: Cannot set player position to a BorderTile at " + position);
+      logger.error("Error: Cannot set player position to a BorderTile at " + position);
       return;
     }
     if (!targetTile.isWalkable()
         && !(targetTile
         instanceof RoomTile)) { // Allow moving into rooms even if "not walkable" squares
-      System.err.println(
+      logger.error(
           "Error: Cannot set player position to a non-walkable tile at "
               + position
               + " of type "
@@ -371,7 +374,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
       if (oldTile != null) {
         oldTile.removePlayer(player);
       } else {
-        System.err.println(
+        logger.warn(
             "Warning: Player " + player.getName() + " had no valid old tile at " + oldPos);
       }
     }
@@ -382,7 +385,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
     if (newTile != null) {
       newTile.addPlayer(player);
     } else {
-      System.err.println(
+      logger.error(
           "CRITICAL Error: New tile is null at valid position "
               + position
               + " for player "
@@ -400,7 +403,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
               if (isValidPosition(startPos)) {
                 AbstractCluedoTile startTile = getTileAtPosition(startPos);
                 if (startTile instanceof BorderTile) {
-                  System.err.println(
+                  logger.error(
                       "CRITICAL Error: Calculated start position "
                           + startPos
                           + " for player "
@@ -409,7 +412,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
                   return;
                 }
                 if (startTile == null) {
-                  System.err.println(
+                  logger.error(
                       "CRITICAL Error: Start tile is null at supposedly valid position "
                           + startPos
                           + " for player "
@@ -423,7 +426,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
 
                 if (!startTile.isWalkable()
                     && !(startTile instanceof RoomTile)) { // Rooms are fine to start in.
-                  System.err.println(
+                  logger.error(
                       "Error: Start tile at "
                           + startPos
                           + " for player "
@@ -434,7 +437,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
                 startTile.addPlayer(player); // Add player to the tile model
 
               } else {
-                System.err.println(
+                logger.error(
                     "Error: Invalid start position "
                         + startPos
                         + " calculated for player "
@@ -474,7 +477,7 @@ public final class CluedoBoard implements GameBoard<GridPos> {
       case BLUE -> START_POS_MRS_PEACOCK;
       case PURPLE -> START_POS_PROF_PLUM;
       default -> {
-        System.err.println("Warning: Unmapped player color for start position: " + color);
+        logger.warn("Warning: Unmapped player color for start position: " + color);
         throw new IllegalArgumentException(
             "Invalid or unmapped player color for start position: " + color);
       }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/controller/CluedoController.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/controller/CluedoController.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Random;
 import javafx.animation.PauseTransition;
 import javafx.util.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Controller for the Cluedo game. Manages game flow, player turns, actions like moving, suggesting,
@@ -43,6 +45,8 @@ public final class CluedoController extends GameController<GridPos> {
   private final List<Player<GridPos>> turnOrder = new ArrayList<>();
   private int currentIndex;
   private Phase phase = Phase.WAIT_ROLL;
+
+  private static final Logger logger = LoggerFactory.getLogger(CluedoController.class);
 
   /**
    * Constructs a CluedoController.
@@ -102,13 +106,13 @@ public final class CluedoController extends GameController<GridPos> {
   @Override
   public void saveGameState(String filePath) {
     // TODO: Implement Cluedo-specific game state saving
-    System.out.println("Cluedo save game state not implemented yet for path: " + filePath);
+    logger.warn("Cluedo save game state not implemented yet for path: {}", filePath);
   }
 
   @Override
   public void loadGameState(String filePath) {
     // TODO: Implement Cluedo-specific game state loading
-    System.out.println("Cluedo load game state not implemented yet from path: " + filePath);
+    logger.warn("Cluedo load game state not implemented yet from path: {}", filePath);
   }
 
   /**
@@ -162,16 +166,16 @@ public final class CluedoController extends GameController<GridPos> {
   }
 
   /**
-   * Handles the action triggered when the roll dice button is pressed. Executes a {@link
-   * RollAction} for the current player.
+   * Handles the action triggered when the roll dice button is pressed. Executes a
+   * {@link RollAction} for the current player.
    */
   public void onRollButton() {
     new RollAction(this, dice).execute();
   }
 
   /**
-   * Handles the action triggered when a tile on the game board is clicked. Executes a {@link
-   * MoveAction} for the current player towards the target position.
+   * Handles the action triggered when a tile on the game board is clicked. Executes a
+   * {@link MoveAction} for the current player towards the target position.
    *
    * @param target The {@link GridPos} of the clicked tile.
    */
@@ -180,24 +184,24 @@ public final class CluedoController extends GameController<GridPos> {
   }
 
   /**
-   * Handles the action triggered when the accuse button is pressed. Executes an {@link
-   * AccusationAction} with the provided suspect, weapon, and room.
+   * Handles the action triggered when the accuse button is pressed. Executes an
+   * {@link AccusationAction} with the provided suspect, weapon, and room.
    *
    * @param suspect The suspected character.
-   * @param weapon The suspected weapon.
-   * @param room The room where the crime is suspected to have occurred.
+   * @param weapon  The suspected weapon.
+   * @param room    The room where the crime is suspected to have occurred.
    */
   public void onAccuseButton(Suspect suspect, Weapon weapon, Room room) {
     new AccusationAction(this, suspect, weapon, room).execute();
   }
 
   /**
-   * Handles the action triggered when the suggest button is pressed. Executes a {@link
-   * SuggestionAction} with the provided suspect, weapon, and room.
+   * Handles the action triggered when the suggest button is pressed. Executes a
+   * {@link SuggestionAction} with the provided suspect, weapon, and room.
    *
    * @param suspect The suspected character involved in the suggestion.
-   * @param weapon The suspected weapon used in the suggestion.
-   * @param room The room where the suggestion is being made.
+   * @param weapon  The suspected weapon used in the suggestion.
+   * @param room    The room where the suggestion is being made.
    */
   public void onSuggestButton(Suspect suspect, Weapon weapon, Room room) {
     new SuggestionAction(this, suspect, weapon, room).execute();
@@ -323,8 +327,8 @@ public final class CluedoController extends GameController<GridPos> {
    * Allows the current player to make an accusation.
    *
    * @param suspect The suspected character.
-   * @param weapon The suspected weapon.
-   * @param room The room where the crime is suspected to have occurred.
+   * @param weapon  The suspected weapon.
+   * @param room    The room where the crime is suspected to have occurred.
    */
   public void makeAccusation(Suspect suspect, Weapon weapon, Room room) {
     if (suspect == null || weapon == null || room == null) {
@@ -378,7 +382,7 @@ public final class CluedoController extends GameController<GridPos> {
    * the method returns null.
    *
    * @return The {@link Room} object representing the current player's location if they are in a
-   *     room, or null if the player is not in a room.
+   * room, or null if the player is not in a room.
    */
   public Room getRoomOfCurrentPlayer() {
     GridPos pos = currentPlayer.getPosition();
@@ -389,7 +393,9 @@ public final class CluedoController extends GameController<GridPos> {
     return null;
   }
 
-  /** Called when this player’s movement finishes. Advances turn. */
+  /**
+   * Called when this player’s movement finishes. Advances turn.
+   */
   public void endTurn() {
     this.phase = Phase.WAIT_ROLL;
     nextTurn();
@@ -411,7 +417,9 @@ public final class CluedoController extends GameController<GridPos> {
     solutionRoom = roomList.remove(0);
   }
 
-  /** Deal the remaining deck clockwise, one at a time, until empty. */
+  /**
+   * Deal the remaining deck clockwise, one at a time, until empty.
+   */
   private void dealRemainingCards() {
     List<Card> deck = new ArrayList<>();
     deck.addAll(Cards.shuffledSuspects(rng));

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/view/CluedoBoardView.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/view/CluedoBoardView.java
@@ -1,5 +1,14 @@
 package edu.ntnu.idi.idatt.boardgame.games.cluedo.view;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.ntnu.idi.idatt.boardgame.core.domain.board.Tile;
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.GridPos;
 import edu.ntnu.idi.idatt.boardgame.core.engine.event.TileObserver;
@@ -10,11 +19,6 @@ import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.board.CorridorTile;
 import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.board.RoomTile;
 import edu.ntnu.idi.idatt.boardgame.ui.util.LoggingNotification;
 import edu.ntnu.idi.idatt.boardgame.ui.util.PlayerTokenFactory;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.stream.IntStream;
 import javafx.application.Platform;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
@@ -40,6 +44,8 @@ import javafx.scene.text.TextAlignment;
  * tiles, particularly rooms.
  */
 public final class CluedoBoardView extends Pane implements TileObserver<GridPos> {
+
+  private static final Logger logger = LoggerFactory.getLogger(CluedoBoardView.class);
 
   private static final int TILE_SIZE = 30;
   private static final int GAP_SIZE = 1;
@@ -354,7 +360,7 @@ public final class CluedoBoardView extends Pane implements TileObserver<GridPos>
     FlowPane pane = roomTokenPanes.get(room);
     if (pane == null) {
       // This can happen if the room wasn't fully initialized or is not in the map
-      // System.err.println("CluedoBoardView: No token pane found for room: " + room.getRoomName());
+      logger.warn("CluedoBoardView: No token pane found for room: {}", room.getRoomName());
       return;
     }
 

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/engine/controller/SnlController.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/engine/controller/SnlController.java
@@ -1,5 +1,15 @@
 package edu.ntnu.idi.idatt.boardgame.games.snakesandladders.engine.controller;
 
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.ntnu.idi.idatt.boardgame.core.domain.dice.Dice;
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.LinearPos;
 import edu.ntnu.idi.idatt.boardgame.core.domain.player.Player;
@@ -12,12 +22,6 @@ import edu.ntnu.idi.idatt.boardgame.games.snakesandladders.engine.action.RollAct
 import edu.ntnu.idi.idatt.boardgame.games.snakesandladders.persistence.dto.SnlGameStateDto;
 import edu.ntnu.idi.idatt.boardgame.games.snakesandladders.persistence.mapper.SnlMapper;
 import edu.ntnu.idi.idatt.boardgame.ui.util.LoggingNotification;
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.stream.IntStream;
 
 /**
  * Controller for the Snakes and Ladders game. Manages game flow, player turns, dice rolls, and game
@@ -41,6 +45,8 @@ public final class SnlController extends GameController<LinearPos> {
       PlayerColor.YELLOW,
       PlayerColor.ORANGE,
       PlayerColor.PURPLE);
+
+  private static final Logger logger = LoggerFactory.getLogger(SnlController.class);
 
   /**
    * Constructs an SnLController.
@@ -135,7 +141,7 @@ public final class SnlController extends GameController<LinearPos> {
       repo.save(SnlMapper.toDto(this), Path.of(path));
       LoggingNotification.info("Game Saved", "Game state saved to " + path);
     } catch (Exception e) {
-      System.err.println("Save failed: " + e.getMessage());
+      logger.error("Save failed: {}", e.getMessage());
       LoggingNotification.error("Save failed", e.getMessage());
     }
   }
@@ -146,7 +152,7 @@ public final class SnlController extends GameController<LinearPos> {
       SnlMapper.apply(repo.load(Path.of(path)), this);
       notifyObservers("Game state loaded. Current turn: " + currentPlayer.getName());
     } catch (Exception e) {
-      System.err.println("Load failed: " + e.getMessage());
+      logger.error("Load failed: {}", e.getMessage());
       LoggingNotification.error("Load failed", e.getMessage());
     }
   }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/MainView.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/MainView.java
@@ -22,12 +22,16 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The {@code MainView} class serves as the primary container for the application, featuring a
  * sidebar with game selection and placeholders for save/load functionality.
  */
 public final class MainView {
+
+  private static final Logger logger = LoggerFactory.getLogger(MainView.class);
 
   private final BorderPane root;
   private final StackPane contentWrapper;
@@ -91,7 +95,7 @@ public final class MainView {
     button.setOnAction(
         e -> {
           if (currentController == null) {
-            System.out.println("No game loaded to save.");
+            logger.warn("No game loaded to save.");
             LoggingNotification.error("No game loaded", "Cannot save game.");
             return;
           }
@@ -102,6 +106,7 @@ public final class MainView {
             boolean success = dir.mkdirs();
 
             if (!success) {
+              logger.error("Failed to create saves directory. Cannot save game.");
               LoggingNotification.error("Failed to create saves directory", "Cannot save game.");
               return;
             }
@@ -113,13 +118,13 @@ public final class MainView {
               .add(new FileChooser.ExtensionFilter("JSON Files", "*.json"));
           Stage stage = getStage();
           if (stage == null) {
-            System.err.println("Could not get the stage to show save dialog.");
+            logger.error("Could not get the stage to show save dialog.");
             LoggingNotification.error("Failed to save game", "Could not get the stage.");
             return;
           }
           File file = chooser.showSaveDialog(stage);
           if (file == null) {
-            System.out.println("Save cancelled.");
+            logger.info("Save cancelled. No file selected.");
             LoggingNotification.info("Save cancelled", "No file selected.");
             return;
           }
@@ -137,7 +142,7 @@ public final class MainView {
           chooser.setTitle("Load Game State");
           File dir = new File("saves");
           if (!dir.exists()) {
-            System.out.println("Saves directory does not exist. Cannot load game.");
+            logger.error("Saves directory does not exist. Cannot load game.");
             LoggingNotification.error("Failed to load game", "Saves directory does not exist.");
             return;
           }
@@ -147,23 +152,24 @@ public final class MainView {
               .add(new FileChooser.ExtensionFilter("JSON Files", "*.json"));
           Stage stage = getStage();
           if (stage == null) {
-            System.err.println("Could not get the stage to show load dialog.");
+            logger.error("Could not get the stage to show load dialog.");
             LoggingNotification.error("Failed to load game", "Could not get the stage.");
             return;
           }
           File file = chooser.showOpenDialog(stage);
           if (file == null) {
-            System.out.println("Load cancelled.");
+            logger.info("Load cancelled. No file selected.");
             return;
           }
           if (currentController == null) {
-            System.out.println("Loading default game (Snakes and Ladders) for the save file.");
+            logger.warn(
+                "No game loaded. Loading default game (Snakes and Ladders) for the save file.");
             LoggingNotification.error(
                 "No game loaded", "Loading default game (Snakes and Ladders) for the save file.");
             loadSnakesAndLadders();
           }
           if (currentController == null) {
-            System.err.println("Failed to initialize a game controller for loading.");
+            logger.error("Failed to initialize a game controller for loading.");
             LoggingNotification.error("Failed to load game", "No game controller available.");
             return;
           }
@@ -189,7 +195,7 @@ public final class MainView {
     try {
       Files.createDirectories(savesDir);
     } catch (IOException e) {
-      System.err.println("Failed to create saves directory: " + e.getMessage());
+      logger.error("Failed to create saves directory: {}", e.getMessage());
       LoggingNotification.error("Failed to create saves directory", "Cannot load game.");
       return;
     }
@@ -218,14 +224,13 @@ public final class MainView {
       loadGameButton.setDisable(true); // Cluedo save/load not implemented
 
     } catch (IllegalArgumentException ex) {
-      System.err.println("Failed to load Cluedo: " + ex.getMessage());
+      logger.error("Failed to load Cluedo: {}", ex.getMessage());
       contentWrapper.getChildren().setAll(new Label("Error loading Cluedo: " + ex.getMessage()));
       saveGameButton.setDisable(true);
       loadGameButton.setDisable(true);
       this.currentController = null;
     } catch (Exception ex) {
-      System.err.println("An unexpected error occurred while loading Cluedo: " + ex.getMessage());
-      ex.printStackTrace();
+      logger.error("An unexpected error occurred while loading Cluedo: {}", ex.getMessage(), ex);
       contentWrapper.getChildren().setAll(new Label("Unexpected error loading Cluedo."));
       saveGameButton.setDisable(true);
       loadGameButton.setDisable(true);

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/util/LoggingNotification.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/util/LoggingNotification.java
@@ -131,7 +131,8 @@ public final class LoggingNotification {
     } catch (IllegalStateException e) {
       // (toolkit not initialized) — swallow or log to console
       logger.warn(
-          "JavaFX toolkit not initialized when trying to show notification. Running on current thread.",
+          "JavaFX toolkit not initialized when trying to show notification."
+              + " Running on current thread.",
           e); // NEW internal log
       r.run();
     }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/util/LoggingNotification.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/ui/util/LoggingNotification.java
@@ -5,25 +5,46 @@ import javafx.geometry.Pos;
 import javafx.scene.image.ImageView;
 import javafx.util.Duration;
 import org.controlsfx.control.Notifications;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility for showing non‑blocking, toast‑style log messages.
  *
  * <p>Uses ControlsFX {@link Notifications}. Must be called on the JavaFX Application Thread.
+ * Also logs the notification to SLF4J logger.
  */
 public final class LoggingNotification {
+
+  private static final Logger logger = LoggerFactory.getLogger(
+      LoggingNotification.class); // NEW LOGGER INSTANCE
 
   private LoggingNotification() {
   }
 
   /**
-   * Shows a notification with sensible defaults for the given log type.
+   * Shows a notification with sensible defaults for the given log type. Also logs the message to
+   * the SLF4J logger.
    *
    * @param type    severity/category (see {@link LoggingType})
    * @param title   short summary
    * @param message detailed message (optional)
    */
   public static void show(LoggingType type, String title, String message) {
+    String fullMessage = (message == null || message.isEmpty()) ? title : title + ": " + message;
+
+    // **** NEW: Log to SLF4J first ****
+    switch (type) {
+      case INFO -> logger.info("[UI INFO] {}", fullMessage);
+      case DEBUG -> logger.debug("[UI DEBUG] {}", fullMessage);
+      case WARN -> logger.warn("[UI WARN] {}", fullMessage);
+      case ERROR -> logger.error("[UI ERROR] {}", fullMessage);
+      case FATAL ->
+          logger.error("[UI FATAL] {}", fullMessage); // SLF4J doesn't have FATAL, maps to ERROR
+      default -> logger.info("[UI UNKNOWN TYPE {}] {}", type, fullMessage);
+    }
+
+    // UI Popup logic remains
     Runnable task = () -> build(type, title, message).show();
     runOnFxThread(task);
   }
@@ -92,7 +113,10 @@ public final class LoggingNotification {
       case WARN -> notifications.graphic(Icon.WARN.view());
       case ERROR -> notifications.graphic(Icon.ERROR.view()).hideAfter(Duration.seconds(6));
       case FATAL -> notifications.graphic(Icon.FATAL.view()).hideAfter(Duration.seconds(8));
-      default -> throw new IllegalStateException("Unexpected value: " + type);
+      default -> {
+        logger.error("Unexpected LoggingType value in build(): {}", type); // NEW internal log
+        throw new IllegalStateException("Unexpected value: " + type);
+      }
     }
     return notifications;
   }
@@ -106,13 +130,13 @@ public final class LoggingNotification {
       }
     } catch (IllegalStateException e) {
       // (toolkit not initialized) — swallow or log to console
+      logger.warn(
+          "JavaFX toolkit not initialized when trying to show notification. Running on current thread.",
+          e); // NEW internal log
       r.run();
     }
   }
 
-  /**
-   * Icon helper.
-   */
   private enum Icon {
     INFO("/icons/info64.png"),
     DEBUG("/icons/debug64.png"),

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,10 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>


### PR DESCRIPTION
This PR replaces `System.out`/`err` with SLF4J logging across `CluedoBoard`, `CluedoController`, `CluedoBoardView`, and `SnlController`, using appropriate log levels. It also adds SLF4J dependencies (`slf4j-api`, `logback-classic`) to `pom.xml`, improves Javadoc formatting in `CluedoController`.
