### PR TITLE
feat(cluedo): implement Cluedo game state saving and loading

### DIFF
--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/RoomTile.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/domain/board/RoomTile.java
@@ -6,9 +6,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
-/**
- * A room described by an ordered list of corner points that form the perimeter.
- */
+/** A room described by an ordered list of corner points that form the perimeter. */
 public final class RoomTile extends AbstractCluedoTile {
 
   private final String roomName;
@@ -19,30 +17,22 @@ public final class RoomTile extends AbstractCluedoTile {
    */
   private final Set<Edge> doorEdges = new HashSet<>();
 
-  /**
-   * The minimum row index this room occupies.
-   */
+  /** The minimum row index this room occupies. */
   private final int minRow;
 
-  /**
-   * The maximum row index this room occupies.
-   */
+  /** The maximum row index this room occupies. */
   private final int maxRow;
 
-  /**
-   * The minimum column index this room occupies.
-   */
+  /** The minimum column index this room occupies. */
   private final int minCol;
 
-  /**
-   * The maximum column index this room occupies.
-   */
+  /** The maximum column index this room occupies. */
   private final int maxCol;
 
   /**
    * Creates a room tile with the given name and outline perimeter.
    *
-   * @param roomName         logical name (“Kitchen”)
+   * @param roomName logical name (“Kitchen”)
    * @param outlinePerimeter ordered points, first = last (minimum 4)
    */
   public RoomTile(String roomName, List<Point> outlinePerimeter) {
@@ -66,10 +56,10 @@ public final class RoomTile extends AbstractCluedoTile {
   /**
    * Marks the edge between a room boundary point and an adjacent corridor point as a doorway.
    *
-   * @param roomBoundaryPoint     The point on the room's boundary.
+   * @param roomBoundaryPoint The point on the room's boundary.
    * @param adjacentCorridorPoint The adjacent point in the corridor.
    * @throws InvalidRoomTileException if roomBoundaryPoint is not on the room's perimeter or if
-   *                                  adjacentCorridorPoint is not outside the room.
+   *     adjacentCorridorPoint is not outside the room.
    */
   public void addDoor(Point roomBoundaryPoint, Point adjacentCorridorPoint) {
     // Check roomBoundaryPoint is actually on the boundary of this room
@@ -178,9 +168,9 @@ public final class RoomTile extends AbstractCluedoTile {
    * must be inside the room.)
    *
    * @param corridorPoint The point in the corridor.
-   * @param door          The door edge to check against.
+   * @param door The door edge to check against.
    * @return True if the corridor point matches one side of the door and the other side is inside
-   * the room.
+   *     the room.
    */
   private boolean corridorMatchesDoor(Point corridorPoint, Edge door) {
     if (door.a().equals(corridorPoint)) {
@@ -214,9 +204,7 @@ public final class RoomTile extends AbstractCluedoTile {
    * @param row The row index.
    * @param col The column index.
    */
-  public record Point(int row, int col) {
-
-  }
+  public record Point(int row, int col) {}
 
   /**
    * Represents an edge connecting two adjacent {@link Point}s on the board. Typically used to
@@ -224,28 +212,14 @@ public final class RoomTile extends AbstractCluedoTile {
    *
    * @param a The first point of the edge.
    * @param b The second point of the edge.
-   * @throws InvalidRoomTileException if the points are not adjacent.
    */
   public record Edge(Point a, Point b) {
 
-    /**
-     * Constructs an Edge. Ensures that the two points are orthogonally adjacent.
-     */
+    /** Constructs an Edge. Ensures that the two points are orthogonally adjacent. */
     public Edge {
       if (Math.abs(a.row() - b.row()) + Math.abs(a.col() - b.col()) != 1) {
         throw new InvalidRoomTileException("Edge must connect adjacent squares: " + a + ", " + b);
       }
-    }
-
-    /**
-     * Checks if this edge is adjacent to the given point (i.e., if the point is one of its
-     * endpoints).
-     *
-     * @param p The point to check.
-     * @return True if the point is one of the endpoints of this edge, false otherwise.
-     */
-    boolean adjacentTo(Point p) {
-      return p.equals(a) || p.equals(b);
     }
 
     @Override

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/Phase.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/Phase.java
@@ -1,0 +1,12 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.engine;
+
+/**
+ * Represents the different phases of a Cluedo game. The game's progression is divided into these
+ * phases, where each phase dictates the allowed actions for players during their turn.
+ */
+public enum Phase {
+  WAIT_ROLL,
+  MOVING,
+  IN_ROOM,
+  TURN_OVER
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/controller/CluedoController.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/engine/controller/CluedoController.java
@@ -480,6 +480,11 @@ public final class CluedoController extends GameController<GridPos> {
     return stepsLeft;
   }
 
+  /**
+   * Sets the number of steps remaining for the current player to move.
+   *
+   * @param stepsLeft The number of steps remaining for the player's movement.
+   */
   public void setStepsLeft(int stepsLeft) {
     this.stepsLeft = stepsLeft;
   }

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/persistence/JsonCluedoGameStateRepository.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/persistence/JsonCluedoGameStateRepository.java
@@ -1,0 +1,34 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.persistence;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import edu.ntnu.idi.idatt.boardgame.core.persistence.GameStateRepository;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.persistence.dto.CluedoGameStateDto;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Concrete implementation of {@link GameStateRepository} for handling the persistence of {@link
+ * CluedoGameStateDto} objects in JSON format. This class provides functionality to save and load
+ * game states to and from files using the Gson library for JSON serialization and deserialization.
+ *
+ * <p>This repository is specifically designed to work with the game state structure defined in
+ * {@link CluedoGameStateDto}.
+ */
+public class JsonCluedoGameStateRepository implements GameStateRepository<CluedoGameStateDto> {
+
+  /** Gson instance for JSON serialization and deserialization. Configured for pretty printing. */
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+  @Override
+  public void save(CluedoGameStateDto dto, Path file) throws IOException {
+    Files.writeString(file, GSON.toJson(dto));
+  }
+
+  @Override
+  public CluedoGameStateDto load(Path file) throws IOException {
+    String json = Files.readString(file);
+    return GSON.fromJson(json, CluedoGameStateDto.class);
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/persistence/dto/CluedoGameStateDto.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/persistence/dto/CluedoGameStateDto.java
@@ -11,7 +11,10 @@ public final class CluedoGameStateDto extends GameStateDto {
   /** id of the player whose turn it is when the game is saved. */
   public int currentPlayerTurn;
 
+  /** Phase of the game when the game is saved. */
   public Phase phase;
+
+  /** Number of steps left for the current player when the game is saved. */
   public int stepsLeft;
 
   /** List of player states. */

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/persistence/dto/CluedoGameStateDto.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/persistence/dto/CluedoGameStateDto.java
@@ -1,0 +1,55 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.persistence.dto;
+
+import edu.ntnu.idi.idatt.boardgame.core.persistence.dto.GameStateDto;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.engine.Phase;
+import java.util.List;
+import java.util.Map;
+
+/** JSON structure persisted on disk for Cluedo. */
+public final class CluedoGameStateDto extends GameStateDto {
+
+  /** id of the player whose turn it is when the game is saved. */
+  public int currentPlayerTurn;
+
+  public Phase phase;
+  public int stepsLeft;
+
+  /** List of player states. */
+  public List<PlayerState> players;
+
+  /** Represents the persisted state of a single Cluedo player. */
+  public static class PlayerState {
+    /** The player's unique ID (1–6). */
+    public int id;
+
+    /** The player's position on the board (row index). */
+    public int row;
+
+    /** The player's position on the board (col index). */
+    public int col;
+
+    /** The player's colour, e.g. "RED", "WHITE". */
+    public String colour;
+
+    /** The suspect cards in this player's hand, as their enum names. */
+    public List<String> suspectHand;
+
+    /** The weapon cards in this player's hand, as their enum names. */
+    public List<String> weaponHand;
+
+    /** The room cards in this player's hand, as their enum names. */
+    public List<String> roomHand;
+
+    /**
+     * For each suspect, whether this player has it marked off in their notes. Key = Suspect.name(),
+     * Value = true/false.
+     */
+    public Map<String, Boolean> suspectNotes;
+
+    /** Same, for weapons. */
+    public Map<String, Boolean> weaponNotes;
+
+    /** Same, for rooms. */
+    public Map<String, Boolean> roomNotes;
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/persistence/mapper/CluedoMapper.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/cluedo/persistence/mapper/CluedoMapper.java
@@ -1,0 +1,139 @@
+package edu.ntnu.idi.idatt.boardgame.games.cluedo.persistence.mapper;
+
+import edu.ntnu.idi.idatt.boardgame.core.domain.player.GridPos;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Room;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Suspect;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.card.Weapon;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.domain.player.CluedoPlayer;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.engine.controller.CluedoController;
+import edu.ntnu.idi.idatt.boardgame.games.cluedo.persistence.dto.CluedoGameStateDto;
+import edu.ntnu.idi.idatt.boardgame.ui.util.LoggingNotification;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Utility class for mapping the state of the Cluedo game between the `CluedoController` domain
+ * object and the `CluedoGameStateDto` persistence structure.
+ */
+public final class CluedoMapper {
+  private CluedoMapper() {}
+
+  /** Snapshot the entire CluedoController state into a DTO. */
+  public static CluedoGameStateDto toDto(CluedoController controller) {
+    CluedoGameStateDto dto = new CluedoGameStateDto();
+    dto.currentPlayerTurn = controller.getCurrentPlayer().getId();
+    dto.phase = controller.getPhase();
+    dto.stepsLeft = controller.getStepsLeft();
+
+    List<CluedoGameStateDto.PlayerState> list = new ArrayList<>();
+    controller
+        .getPlayers()
+        .values()
+        .forEach(
+            raw -> {
+              CluedoPlayer player = (CluedoPlayer) raw;
+              CluedoGameStateDto.PlayerState playerState = new CluedoGameStateDto.PlayerState();
+
+              playerState.id = player.getId();
+              playerState.row = player.getPosition().row();
+              playerState.col = player.getPosition().col();
+              playerState.colour = player.getColor().name();
+
+              // build hand‐lists (by enum name)
+              playerState.suspectHand = new ArrayList<>();
+              Arrays.stream(Suspect.values())
+                  .filter(player::hasCard)
+                  .forEach(suspect -> playerState.suspectHand.add(suspect.name()));
+              playerState.weaponHand = new ArrayList<>();
+              Arrays.stream(Weapon.values())
+                  .filter(player::hasCard)
+                  .forEach(weapon -> playerState.weaponHand.add(weapon.name()));
+              playerState.roomHand = new ArrayList<>();
+              Arrays.stream(Room.values())
+                  .filter(player::hasCard)
+                  .forEach(room -> playerState.roomHand.add(room.name()));
+
+              // build note‐maps
+              playerState.suspectNotes = new HashMap<>();
+              Arrays.stream(Suspect.values())
+                  .forEach(
+                      suspect ->
+                          playerState.suspectNotes.put(
+                              suspect.name(), player.isSuspectNoted(suspect)));
+              playerState.weaponNotes = new HashMap<>();
+              Arrays.stream(Weapon.values())
+                  .forEach(
+                      weapon ->
+                          playerState.weaponNotes.put(weapon.name(), player.isWeaponNoted(weapon)));
+              playerState.roomNotes = new HashMap<>();
+              Arrays.stream(Room.values())
+                  .forEach(
+                      room -> playerState.roomNotes.put(room.name(), player.isRoomNoted(room)));
+
+              list.add(playerState);
+            });
+
+    dto.players = list;
+    return dto;
+  }
+
+  /** Apply a previously‐saved DTO back onto a fresh CluedoController. */
+  public static void apply(CluedoGameStateDto dto, CluedoController controller) {
+    dto.players.forEach(
+        playerState -> {
+          CluedoPlayer player = (CluedoPlayer) controller.getPlayers().get(playerState.id);
+          if (player == null) {
+            LoggingNotification.error("Load error", "No player with id " + playerState.id);
+            throw new IllegalStateException("No player with id " + playerState.id);
+          }
+
+          // restore position
+          controller
+              .getGameBoard()
+              .setPlayerPosition(player, new GridPos(playerState.row, playerState.col));
+
+          // restore hand
+          playerState.suspectHand.stream()
+              .map(Suspect::valueOf)
+              .filter(suspect -> !player.hasCard(suspect))
+              .forEach(player::addCard);
+          playerState.weaponHand.stream()
+              .map(Weapon::valueOf)
+              .filter(weapon -> !player.hasCard(weapon))
+              .forEach(player::addCard);
+          playerState.roomHand.stream()
+              .map(Room::valueOf)
+              .filter(room -> !player.hasCard(room))
+              .forEach(player::addCard);
+
+          // restore notes
+          playerState.suspectNotes.forEach(
+              (name, noted) -> {
+                Suspect suspect = Suspect.valueOf(name);
+                player.setSuspectNoted(suspect, noted);
+              });
+          playerState.weaponNotes.forEach(
+              (name, noted) -> {
+                Weapon weapon = Weapon.valueOf(name);
+                player.setWeaponNoted(weapon, noted);
+              });
+          playerState.roomNotes.forEach(
+              (name, noted) -> {
+                Room room = Room.valueOf(name);
+                player.setRoomNoted(room, noted);
+              });
+        });
+
+    // restore whose turn it is
+    CluedoPlayer current = (CluedoPlayer) controller.getPlayers().get(dto.currentPlayerTurn);
+    if (current == null) {
+      LoggingNotification.error("Load error", "No player with id " + dto.currentPlayerTurn);
+      throw new IllegalStateException("No player with id " + dto.currentPlayerTurn);
+    }
+    controller.setPhase(dto.phase);
+    controller.setStepsLeft(dto.stepsLeft);
+    controller.setCurrentPlayer(current);
+  }
+}

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/persistence/mapper/SnlMapper.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/games/snakesandladders/persistence/mapper/SnlMapper.java
@@ -14,9 +14,7 @@ import java.util.List;
  */
 public final class SnlMapper {
 
-  /**
-   * Private constructor to prevent instantiation.
-   */
+  /** Private constructor to prevent instantiation. */
   private SnlMapper() {
     // Utility class
   }
@@ -52,7 +50,7 @@ public final class SnlMapper {
    * modifies the controller to reflect the loaded game state. Note: This assumes the
    * SnLController's players map is already initialized with the correct number of players and IDs.
    *
-   * @param dto        The game state DTO to apply.
+   * @param dto The game state DTO to apply.
    * @param controller The game controller to update.
    * @throws IllegalStateException if a player ID from the DTO is not found in the controller.
    */


### PR DESCRIPTION
Add a JSON-based repository for persisting Cluedo game states and integrate it into the CluedoController. Introduce a mapper utility to convert between CluedoController and DTOs, as well as support for game phases, player details, and board positions. Update MainView for save/load functionality and remove deprecated CluedoController enums.