### PR TITLE
Add AtlantaFX PrimerLight theme to the application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
       <artifactId>logback-classic</artifactId>
       <version>1.5.18</version>
     </dependency>
+    <dependency>
+      <groupId>io.github.mkpaz</groupId>
+      <artifactId>atlantafx-base</artifactId>
+      <version>2.0.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/edu/ntnu/idi/idatt/boardgame/App.java
+++ b/src/main/java/edu/ntnu/idi/idatt/boardgame/App.java
@@ -1,5 +1,6 @@
 package edu.ntnu.idi.idatt.boardgame;
 
+import atlantafx.base.theme.PrimerLight;
 import edu.ntnu.idi.idatt.boardgame.ui.MainView;
 import javafx.application.Application;
 import javafx.scene.Scene;
@@ -16,10 +17,11 @@ public final class App extends Application {
    * has returned, and after the system is ready for the application to begin running.
    *
    * @param stage the primary stage for this application, onto which the application scene can be
-   *              set.
+   *     set.
    */
   @Override
   public void start(Stage stage) {
+    Application.setUserAgentStylesheet(new PrimerLight().getUserAgentStylesheet());
     MainView mainView = new MainView();
     Scene scene = new Scene(mainView.getRoot(), 900, 800);
     stage.setScene(scene);


### PR DESCRIPTION
Integrate the AtlantaFX PrimerLight theme by updating the `pom.xml` with the necessary dependency and applying it in the `App` class. This enhances the application's UI with the selected modern theme.